### PR TITLE
修复service worker的路径

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -32,7 +32,7 @@
 <script>
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
-    navigator.serviceWorker.register('\service-worker.js').then(function(reg) {
+    navigator.serviceWorker.register('/service-worker.js').then(function(reg) {
       reg.onupdatefound = function() {
         var installingWorker = reg.installing;
         installingWorker.onstatechange = function() {


### PR DESCRIPTION
之前把一个斜杠打反了。。非常尴尬

打反会导致页面注册多个service worker